### PR TITLE
Change language in one place

### DIFF
--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -169,7 +169,6 @@ class Nav extends React.PureComponent {
   }
 
   handleLangSelection(event) {
-    i18next.changeLanguage(event.target.value);
     this.props.setLanguage(event.target.value);
     this.props.showToast(1500);
     this.props.setToastText('Toast.LangChange');

--- a/client/modules/IDE/actions/preferences.js
+++ b/client/modules/IDE/actions/preferences.js
@@ -211,14 +211,15 @@ export function setAllAccessibleOutput(value) {
   };
 }
 
-export function setLanguage(value) {
+export function setLanguage(value, { persistPreference = true } = {}) {
   return (dispatch, getState) => {
+    i18next.changeLanguage(value);
     dispatch({
       type: ActionTypes.SET_LANGUAGE,
       language: value
     });
     const state = getState();
-    if (state.user.authenticated) {
+    if (persistPreference && state.user.authenticated) {
       const formParams = {
         preferences: {
           language: value

--- a/client/modules/User/actions.js
+++ b/client/modules/User/actions.js
@@ -2,6 +2,7 @@ import { browserHistory } from 'react-router';
 import * as ActionTypes from '../../constants';
 import apiClient from '../../utils/apiClient';
 import { showErrorModal, justOpenedProject } from '../IDE/actions/ide';
+import { setLanguage } from '../IDE/actions/preferences';
 import { showToast, setToastText } from '../IDE/actions/toast';
 
 export function authError(error) {
@@ -60,10 +61,7 @@ export function validateAndLoginUser(previousPath, formProps, dispatch) {
           preferences: response.data.preferences
         });
         const valorLanguage = response.data.preferences.language;
-        dispatch({
-          type: ActionTypes.SET_LANGUAGE,
-          language: valorLanguage
-        });
+        setLanguage(valorLanguage, { persistPreference: false });
         dispatch(justOpenedProject());
         browserHistory.push(previousPath);
         resolve();
@@ -85,10 +83,7 @@ export function getUser() {
           type: ActionTypes.SET_PREFERENCES,
           preferences: response.data.preferences
         });
-        dispatch({
-          type: ActionTypes.SET_LANGUAGE,
-          language: response.data.preferences.language
-        });
+        setLanguage(response.data.preferences.language, { persistPreference: false });
       }).catch((error) => {
         const { response } = error;
         const message = response.message || response.data.error;


### PR DESCRIPTION
Hi,

I was looking at your PR  processing/p5.js-web-editor#1536. It's good, but I think it makes more sense for the`setLanguage` action to perform the `i18next.changeLanguage` call. This way, any part of the code can call `setLanguage` and the language will change correctly.

What do you think?